### PR TITLE
Update Dockerfile

### DIFF
--- a/dev-1404/Dockerfile
+++ b/dev-1404/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get update && apt-get install -y \
   python \
   wget \
   openjdk-7-jdk \
-  nano
+  nano \
+  libxml2-utils
 
 # where the files exist
 VOLUME /opt/sourcecode


### PR DESCRIPTION
Need libxml2-utils when the build is using the xmllint command
