### PR TITLE
headless readme: load unsafe scripts

### DIFF
--- a/chrome-headless/README.md
+++ b/chrome-headless/README.md
@@ -13,3 +13,7 @@ Access in Chrome at:
 ```
 http://localhost:9222/
 ```
+You may have to _Load unsafe scripts_ from the omnibox shield icon to allow connecting to the insecure websocket endpoint `ws://localhost:9222`:
+<center>
+![image](https://cloud.githubusercontent.com/assets/39191/21593324/b3e92618-d0ca-11e6-9472-d07b9b9df2c9.png)
+</center>


### PR DESCRIPTION
Once I did this, everything was gravy.