### PR TITLE
Missing v argument in the run command

### DIFF
--- a/lighthouse/README.md
+++ b/lighthouse/README.md
@@ -16,7 +16,7 @@ Using the ever-awesome [Jessie Frazelle](https://twitter.com/jessfraz) SECCOMP p
 
 ```
 $ wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -O ~/chrome.json
-$ docker run -it ~/your-local-dir:/home/chrome/reports --security-opt seccomp=$HOME/chrome.json justinribeiro/lighthouse
+$ docker run -itv ~/your-local-dir:/home/chrome/reports --security-opt seccomp=$HOME/chrome.json justinribeiro/lighthouse
 ```
 
 ## Step 2: Run Lighthouse with `--chrome-flags`

--- a/lighthouse/README.md
+++ b/lighthouse/README.md
@@ -7,7 +7,7 @@
 ## Step 1: Run the container
 
 ```
-docker run -it ~/your-local-dir:/home/chrome/reports --cap-add=SYS_ADMIN justinribeiro/lighthouse
+docker run -itv ~/your-local-dir:/home/chrome/reports --cap-add=SYS_ADMIN justinribeiro/lighthouse
 ```
 
 ## Step 1 Improved: A better way with SECCOMP


### PR DESCRIPTION
There is a missing v argument to the example command line in the documentation.
It causes the following error message:

```
docker: invalid reference format: repository name must be lowercase.
See 'docker run --help'.
```