### PR TITLE
Lighthouse: NPM dependency

### DIFF
--- a/lighthouse/Dockerfile
+++ b/lighthouse/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get install -y \
   && apt-get update && apt-get install -y \
     google-chrome-stable \
     nodejs \
+    npm \
     --no-install-recommends \
   && apt-get purge --auto-remove -y curl gnupg \
   && rm -rf /var/lib/apt/lists/*

--- a/lighthouse/Dockerfile
+++ b/lighthouse/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get install -y \
   && apt-get update && apt-get install -y \
     google-chrome-stable \
     nodejs \
+		npm \
     --no-install-recommends \
   && apt-get purge --auto-remove -y curl gnupg \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Missing NPM dependency which is not installed alongside NodeJS in Debian (https://unix.stackexchange.com/questions/445206/nodejs-deb-package-seems-to-miss-npm)

Also resolves the issue #45 