### PR TITLE
Move to chromium for arm64 support and use debian bullseye for chrome-headless

### DIFF
--- a/chrome-headless/Dockerfile
+++ b/chrome-headless/Dockerfile
@@ -1,12 +1,12 @@
-# Run Chrome Headless in a container
+# Run chromium Headless in a container
 #
 # What was once a container using the experimental build of headless_shell from
-# tip, this container now runs and exposes stable Chrome headless via
+# tip, this container now runs and exposes stable chromium headless via
 # google-chome --headless.
 #
 # What's New
 #
-# 1. Pulls from Chrome Stable
+# 1. Pulls from chromium Stable
 # 2. You can now use the ever-awesome Jessie Frazelle seccomp profile for Chrome.
 #     wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -O ~/chrome.json
 #
@@ -17,15 +17,15 @@
 # To run a better way (with seccomp):
 # docker run -d -p 9222:9222 --security-opt seccomp=$HOME/chrome.json justinribeiro/chrome-headless
 #
-# Basic use: open Chrome, navigate to http://localhost:9222/
+# Basic use: open chromium, navigate to http://localhost:9222/
 #
 
 # Base docker image
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 LABEL name="chrome-headless" \
 	maintainer="Justin Ribeiro <justin@justinribeiro.com>" \
 	version="3.0" \
-	description="Google Chrome Headless in a container"
+	description="Chromium Headless in a container"
 
 # Install deps + add Chrome Stable + purge all the things
 RUN apt-get update && apt-get install -y \
@@ -34,10 +34,9 @@ RUN apt-get update && apt-get install -y \
 	curl \
 	gnupg \
 	--no-install-recommends \
-	&& curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
-	&& echo "deb https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
 	&& apt-get update && apt-get install -y \
-	google-chrome-stable \
+	chromium \
+	chromium-sandbox \
 	fontconfig \
 	fonts-ipafont-gothic \
 	fonts-wqy-zenhei \
@@ -50,16 +49,16 @@ RUN apt-get update && apt-get install -y \
 	&& apt-get purge --auto-remove -y curl gnupg \
 	&& rm -rf /var/lib/apt/lists/*
 
-# Add Chrome as a user
-RUN groupadd -r chrome && useradd -r -g chrome -G audio,video chrome \
-	&& mkdir -p /home/chrome && chown -R chrome:chrome /home/chrome
+# Add chromium as a user
+RUN groupadd -r chromium && useradd -r -g chromium -G audio,video chromium \
+	&& mkdir -p /home/chromium && chown -R chromium:chromium /home/chromium
 
-# Run Chrome non-privileged
-USER chrome
+# Run chromium non-privileged
+USER chromium
 
 # Expose port 9222
 EXPOSE 9222
 
-# Autorun chrome headless with no GPU
-ENTRYPOINT [ "google-chrome" ]
+# Autorun chromium headless with no GPU
+ENTRYPOINT [ "chromium" ]
 CMD [ "--headless", "--disable-gpu", "--remote-debugging-address=0.0.0.0", "--remote-debugging-port=9222" ]

--- a/chrome-headless/README.md
+++ b/chrome-headless/README.md
@@ -46,3 +46,9 @@ Depending on the current build, if you run the container interactively you may s
 [0501/162901.033169:WARNING:audio_manager.cc(254)] Multiple instances of AudioManager detected
 ```
 In most cases, these messages can be safely ignored. They will sometimes change and eventually as things are updated in the source tree, resolved.
+
+## Building and Pushing
+
+To build, `./build.sh <tag>`, for example ./build.sh justinbeiro/chrome-headless:20211007-chromium
+
+To push, `./build.sh <tag>`, for example `./push.sh justinbeiro/chrome-headless:20211007-chromium`. This will push both amd64 and arm64 images.

--- a/chrome-headless/build.sh
+++ b/chrome-headless/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ $# != 1 ]; then
-  echo "\$1 must be the tag, like justinbeiro/headless-chrome:20211007-chromium" && exit 1
+  echo "\$1 must be the tag, like justinribeiro/headless-chrome:20211007-chromium" && exit 1
 fi
 tag=$1
 

--- a/chrome-headless/build.sh
+++ b/chrome-headless/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ $# != 1 ]; then
+  echo "\$1 must be the tag, like justinbeiro/headless-chrome:20211007-chromium" && exit 1
+fi
+tag=$1
+
+# Build only the current architecture
+docker buildx build -o type=docker -t ${tag} .

--- a/chrome-headless/build.sh
+++ b/chrome-headless/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ $# != 1 ]; then
-  echo "\$1 must be the tag, like justinribeiro/headless-chrome:20211007-chromium" && exit 1
+  echo "\$1 must be the tag, like justinribeiro/chrome-headless:20211007-chromium" && exit 1
 fi
 tag=$1
 

--- a/chrome-headless/push.sh
+++ b/chrome-headless/push.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ $# != 1 ]; then
-  echo "\$1 must be the push-to image, like justinribeiro/headless-chrome:20211007-chromium" && exit 1
+  echo "\$1 must be the push-to image, like justinribeiro/chrome-headless:20211007-chromium" && exit 1
 fi
 pushto=$1
 

--- a/chrome-headless/push.sh
+++ b/chrome-headless/push.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ $# != 1 ]; then
+  echo "\$1 must be the push-to image, like justinbeiro/headless-chrome:20211007-chromium" && exit 1
+fi
+pushto=$1
+
+# build and push both arm64 and amd64 architectures
+docker buildx build --push --platform=linux/arm64,linux/amd64 -t ${pushto} .

--- a/chrome-headless/push.sh
+++ b/chrome-headless/push.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ $# != 1 ]; then
-  echo "\$1 must be the push-to image, like justinbeiro/headless-chrome:20211007-chromium" && exit 1
+  echo "\$1 must be the push-to image, like justinribeiro/headless-chrome:20211007-chromium" && exit 1
 fi
 pushto=$1
 


### PR DESCRIPTION
This moves chrome-headless using the chromium packages, which are provided for both amd64 and arm64.

This gets a far more recent version of chromium, and provides build and push tools. 

Example pushed images: `docker run -d -p 9222:9222 --cap-add=SYS_ADMIN randyfay/chrome-headless:20211007-chromium` on either arm64 (Mac M1) or amd64 architectures.